### PR TITLE
Use Stravalib

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 Flask>=1.0.0
 cloudant==2.4.0
-git+https://github.com/sladkovm/strava-swagger-client.git
+stravalib==0.10.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Flask>=1.0.0
 cloudant==2.4.0
+git+https://github.com/sladkovm/strava-swagger-client.git

--- a/strava.py
+++ b/strava.py
@@ -3,6 +3,8 @@ A crappy Strava helper module
 """
 import requests
 
+import stravalib
+
 strava_token_url = "https://www.strava.com/oauth/token"
 strava_leaderboard_url = "https://www.strava.com/api/v3/segments/{}/leaderboard?&club_id={}&date_range={}&per_page={}"
 hop_club = 631182
@@ -64,11 +66,14 @@ def refresh_access_token(client_id, secret, refresh_token):
 # *
 # * docs: https://developers.strava.com/docs/reference/#api-Segments-getLeaderboardBySegmentId
 def segment_leaderboard(segment_id, token, club_id, date_range):
-    segment_url = strava_leaderboard_url.format(segment_id,club_id,date_range,"50")
-    print("getting {}".format(segment_url))
-    leader_result = requests.get(segment_url, headers={'Content-Type':'application/json','Authorization': 'Bearer {}'.format(token)})
+    print("getting segment leaderboard")
+    client = stravalib.Client(token)
+    leader_result = client.get_segment_leaderboard(
+        segment_id, club_id=club_id, timeframe=date_range)
     print(leader_result)
-    return leader_result.json()['entries']
+    result_dict = [entry.log.__dict__ for entry in leader_result] 
+    print(result_dict)
+    return result_dict
 
 # Gather hop segment leaders for a given date range
 def hop_segment_leaders(token, date_range):
@@ -76,3 +81,4 @@ def hop_segment_leaders(token, date_range):
     for (segment_id,name) in hop_segments.items():
         segment_leaders[name] = segment_leaderboard(segment_id, token, hop_club, date_range)
     return segment_leaders
+

--- a/strava.py
+++ b/strava.py
@@ -1,9 +1,11 @@
 """
 A crappy Strava helper module
 """
+from typing import Dict
 import requests
 
 import stravalib
+
 
 strava_token_url = "https://www.strava.com/oauth/token"
 strava_leaderboard_url = "https://www.strava.com/api/v3/segments/{}/leaderboard?&club_id={}&date_range={}&per_page={}"
@@ -68,12 +70,12 @@ def refresh_access_token(client_id, secret, refresh_token):
 def segment_leaderboard(segment_id, token, club_id, date_range):
     print("getting segment leaderboard")
     client = stravalib.Client(token)
-    leader_result = client.get_segment_leaderboard(
+    leaderboard = client.get_segment_leaderboard(
         segment_id, club_id=club_id, timeframe=date_range)
+    leader_result = [get_leaderboard_entry_dict(entry)
+                     for entry in leaderboard]
     print(leader_result)
-    result_dict = [entry.log.__dict__ for entry in leader_result] 
-    print(result_dict)
-    return result_dict
+    return leader_result
 
 # Gather hop segment leaders for a given date range
 def hop_segment_leaders(token, date_range):
@@ -82,3 +84,23 @@ def hop_segment_leaders(token, date_range):
         segment_leaders[name] = segment_leaderboard(segment_id, token, hop_club, date_range)
     return segment_leaders
 
+
+def get_leaderboard_entry_dict(
+        entry: stravalib.model.SegmentLeaderboardEntry) -> Dict:
+    """Extract leaderboard entries to dict for table rendering.
+
+    Args:
+        entry: segment leaderboard entry extract elements
+
+    Returns
+        Dict with the following keys: athlete_name, elapsed_time, moving_time,
+        start_date, start_date_local, rank
+    """
+    return {
+        "athlete_name": entry.athlete_name,
+        "elapsed_time": entry.elapsed_time,
+        "moving_time": entry.moving_time,
+        "start_date": entry.start_date,
+        "start_date_local": entry.start_date_local,
+        "rank": entry.rank}
+    


### PR DESCRIPTION
This updates the leaderboard request to go through the Stravalib library.  It's a little bit hokey because the model objects in that library don't support dict conversion well... the builtin `vars()` method doesn't work on the model attributes, it only returns the attributes of the base class.

We might not want to merge this yet.  I'm going to see if another library comes out cleaner.  There's a different library that's generated using Swagger codegen that might work better.  