### PR TITLE
Cloudant flask extension

### DIFF
--- a/database.py
+++ b/database.py
@@ -24,6 +24,9 @@ class FlaskCloudant(object):
             CLOUDANT_USERNAME
             CLOUDANT_PASSWORD
             CLOUDANT_URL
+
+        If necessary, these can be overridden by setting the repsective
+        parameters in the Flask app config.
         """
         if 'VCAP_SERVICES' in os.environ:
             vcap = json.loads(os.getenv('VCAP_SERVICES'))

--- a/database.py
+++ b/database.py
@@ -1,0 +1,84 @@
+"""Services and utilities for Cloudant database."""
+import os
+import json
+import warnings
+
+import cloudant
+import flask
+from flask import current_app, _app_ctx_stack
+
+
+class FlaskCloudant(object):
+    """Flask extension that connects to CloudantDB."""
+    def __init__(self, app=None):
+        self.app = app
+        if app is not None:
+            self.init_app(app)
+
+    def init_app(self, app: flask.Flask):
+        """Initialize the extension.
+
+        Based on VCAP_SERVICES in environment or vcap-local.json (if present)
+        sets the following default app config parameters:
+            CLOUDANT_DB_NAME
+            CLOUDANT_USERNAME
+            CLOUDANT_PASSWORD
+            CLOUDANT_URL
+        """
+        if 'VCAP_SERVICES' in os.environ:
+            vcap = json.loads(os.getenv('VCAP_SERVICES'))
+            if 'cloudantNoSQLDB' in vcap:
+                creds = vcap['cloudantNoSQLDB'][0]['credentials']
+                app.logger.info(
+                    "Setting default Cloudant user, password, and host "
+                    "based on file VCAP_SERVICES.")
+        elif os.path.isfile('vcap-local.json'):
+            with open('vcap-local.json') as f:
+                vcap = json.load(f)
+                creds = vcap['services']['cloudantNoSQLDB'][0]['credentials']
+                app.logger.info(
+                    "Setting default Cloudant user, password, and host "
+                    "based on file vcap-local.json.")
+        else:
+            app.logger.warning(
+                "Failed to access VCAP credentials to set defaults"
+                "for Cloudant extension.")
+
+        app.config.setdefault('CLOUDANT_DB_NAME', 'mydb')
+        app.config.setdefault('CLOUDANT_USERNAME', creds['username'])
+        app.config.setdefault('CLOUDANT_PASSWORD', creds['password'])
+        app.config.setdefault('CLOUDANT_URL', f"https://{creds['host']}")
+        app.teardown_appcontext(self.teardown)
+
+    def connect(self):
+        """Connect to the database based on app configuration."""
+        client = cloudant.Cloudant(current_app.config['CLOUDANT_USERNAME'],
+                                   current_app.config['CLOUDANT_PASSWORD'],
+                                   url=current_app.config['CLOUDANT_URL'],
+                                   connect=True)
+        return client
+
+    def teardown(self, exception):
+        ctx = _app_ctx_stack.top
+        if hasattr(ctx, 'cloudant_client'):
+            ctx.cloudant_client.disconnect()
+
+    @property
+    def client(self):
+        """The Cloudant client object connected to the database host."""
+        ctx = _app_ctx_stack.top
+        if ctx is not None:
+            if not hasattr(ctx, 'cloudant_client'):
+                ctx.cloudant_client = self.connect()
+            return ctx.cloudant_client
+
+    @property
+    def db(self):
+        """The Cloudant DB connection connected through the client."""
+        ctx = _app_ctx_stack.top
+        if ctx is not None:
+            if not hasattr(ctx, 'cloudant_db'):
+                ctx.cloudant_db = self.client.create_database(
+                    current_app.config['CLOUDANT_DB_NAME'],
+                    throw_on_exists=False)
+            return ctx.cloudant_db

--- a/segmund.py
+++ b/segmund.py
@@ -101,14 +101,10 @@ def register_user():
 
 @app.route('/users', methods=['GET'])
 def get_users():
-    if cloudant_ext.client:
-        firstname = request.args.get('firstname')
-        selector = {'type': {'$eq': 'user'}}
-        docs = cloudant_ext.db.get_query_result(selector)
-        return render_template('users.html', users=docs, firstname=firstname)
-    else:
-        print('No database')
-        return jsonify([])
+    firstname = request.args.get('firstname')
+    selector = {'type': {'$eq': 'user'}}
+    docs = cloudant_ext.db.get_query_result(selector)
+    return render_template('users.html', users=docs, firstname=firstname)
 
 @atexit.register
 def shutdown():


### PR DESCRIPTION
This PR creates a flask extension to connect to the Cloudant DB.  It's just part of #6, as it doesn't actually factor any database model logic into a service.

Creating an extension puts a bit of structure around how things get configured.  Most importantly, it makes sure that things get set up in the right order.  Assigning objects to module scope can lead to a lot of issues with configuration in Python if you're not careful.  Essentially, the module-level variables get set up as soon as any module sets things up. 

I pushed the logic of VCAP env/local down into this module.  Depending on how we configure things later, this could be simplified and moved elsewhere, but I kind of like it this way.  The VCAP stuff just gets set as defaults, and can be overridden with Flask config variables.
