### PR TITLE
Suppress stravalib mapping warnings

### DIFF
--- a/strava.py
+++ b/strava.py
@@ -7,7 +7,7 @@ import stravalib
 
 import date_utils
 import models
-
+import logging
 
 class Strava:
 
@@ -23,6 +23,7 @@ class Strava:
     }
 
     def __init__(self, config):
+        logging.getLogger("stravalib.attributes.EntityCollection").setLevel("ERROR") # Silence Warnings
         self.client_id = config['STRAVA_CLIENT_ID']
         self.secret = config['STRAVA_SECRET']
 
@@ -127,7 +128,7 @@ class Strava:
                             "segment_name":effort.name,
                             "rank": "N/A",
                             "athlete_id": str(activity.athlete.id),
-                            "athlete_name": 
+                            "athlete_name":
                                 f"{user.firstname}, {user.lastname}",
                             "activity": activity.name,
                             "start_date_local": str(activity.start_date_local),
@@ -141,7 +142,7 @@ class Strava:
         }
         return segment_leaders_sorted
 
-        
+
     def get_public_activities(self, user, start_date, end_date):
         """Return detailed public activities for a given user beteen two dates"""
         token = self.get_user_access_token(user)
@@ -170,7 +171,7 @@ class Strava:
                 client_secret=self.secret,
                 refresh_token=user.refresh_token)
             # update the user with their new token and expiration
-            
+
             user.access_token = refresh_response['access_token']
             user.refresh_token = refresh_response['refresh_token']
             user.expires_at = refresh_response['expires_at']


### PR DESCRIPTION
Context: logs/console are littered with these on every segment effort because current stravalib will log a warning that Strava is returning a new attribute that it's not familiar with:
`Unable to set attribute average_grade_adjusted_speed on entity`

Is there a better way to do this for #7 ?

Alternatively we fork stravalib and add support for this property but that feels heavy.